### PR TITLE
[docs] missing comma for Rack example

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -165,7 +165,7 @@ To start using the middleware in your generic Rack application, add it to your `
 To modify the default middleware configuration, you can use middleware options as follows:
 
     # config.ru example
-    use Datadog::Contrib::Rack::TraceMiddleware default_service: 'rack-stack'
+    use Datadog::Contrib::Rack::TraceMiddleware, default_service: 'rack-stack'
 
     app = proc do |env|
       [ 200, {'Content-Type' => 'text/plain'}, "OK" ]


### PR DESCRIPTION
```use Datadog::Contrib::Rack::TraceMiddleware, default_service: 'rack-stack'```